### PR TITLE
Incorrect Accept header supplied by proxy to transformer

### DIFF
--- a/src/main/java/eu/fusepool/p3/proxy/ProxyHandler.java
+++ b/src/main/java/eu/fusepool/p3/proxy/ProxyHandler.java
@@ -274,7 +274,13 @@ public class ProxyHandler extends AbstractHandler {
                         }
                     }
                 };
-                Entity transformationResult = transformer.transform(entity);
+                
+                Entity transformationResult;
+                try {
+                    transformationResult = transformer.transform(entity, new MimeType("*/*"));
+                } catch (MimeTypeParseException ex) {
+                    throw new RuntimeException(ex);
+                }
                 
                 //final HttpEntity httpEntity = response.getEntity();
                 //final Header contentTypeHeader = httpEntity.getContentType();


### PR DESCRIPTION
If acceptedFormats is not supplied to Transformer.transform(), the Accept header supplied by the proxy via the Transformer Client defaults to 'Accept: text/html, image/gif, image/jpeg, _; q=.2, */_; q=.2'. The Virtuoso transformers return '406 Unacceptable' as a result.
